### PR TITLE
fix: avoid pkg_resources for get_trame_versions()

### DIFF
--- a/trame_vuetify/ui/vuetify.py
+++ b/trame_vuetify/ui/vuetify.py
@@ -10,12 +10,15 @@ __all__ = [
 
 
 def get_trame_versions():
-    import pkg_resources
+    import importlib.metadata
+    from trame_client.utils.version import get_version
 
     output = []
-    for pkg in pkg_resources.working_set:
-        if pkg.key.startswith("trame"):
-            output.append(f"{pkg.key.replace('trame-', '')} == {pkg.version}")
+    for pkg in importlib.metadata.distributions():
+        name = pkg.metadata["Name"]
+        if name.startswith("trame"):
+            version = get_version(name)
+            output.append(f"{name.replace('trame-', '')} == {version}")
 
     return "\n".join(output)
 

--- a/trame_vuetify/ui/vuetify3.py
+++ b/trame_vuetify/ui/vuetify3.py
@@ -10,12 +10,15 @@ __all__ = [
 
 
 def get_trame_versions():
-    import pkg_resources
+    import importlib.metadata
+    from trame_client.utils.version import get_version
 
     output = []
-    for pkg in pkg_resources.working_set:
-        if pkg.key.startswith("trame"):
-            output.append(f"{pkg.key.replace('trame-', '')} == {pkg.version}")
+    for pkg in importlib.metadata.distributions():
+        name = pkg.metadata["Name"]
+        if name.startswith("trame"):
+            version = get_version(name)
+            output.append(f"{name.replace('trame-', '')} == {version}")
 
     return "\n".join(output)
 


### PR DESCRIPTION
`pkg_resources` is not always available for newer setups. But since trame requires python 3.8, `importlib.metadata` can be used instead. Update `get_trame_versions()` to use `importlib.metadata` instead of `pkg_resources`.