### PR TITLE
fix(get_trame_versions): avoid errors

### DIFF
--- a/trame_vuetify/ui/vuetify.py
+++ b/trame_vuetify/ui/vuetify.py
@@ -15,7 +15,7 @@ def get_trame_versions():
 
     output = []
     for pkg in importlib.metadata.distributions():
-        name = pkg.metadata["Name"]
+        name = pkg.metadata.get("Name", "")
         if name.startswith("trame"):
             version = get_version(name)
             output.append(f"{name.replace('trame-', '')} == {version}")

--- a/trame_vuetify/ui/vuetify3.py
+++ b/trame_vuetify/ui/vuetify3.py
@@ -15,7 +15,7 @@ def get_trame_versions():
 
     output = []
     for pkg in importlib.metadata.distributions():
-        name = pkg.metadata["Name"]
+        name = pkg.metadata.get("Name", "")
         if name.startswith("trame"):
             version = get_version(name)
             output.append(f"{name.replace('trame-', '')} == {version}")


### PR DESCRIPTION
For some currently unknown reason, not every PathDistribution contains a "Name" in the metadata. These are probably not trame packages and thus we can probably just ignore them. But if we notice that we are missing trame packages in the future, we should potentially find an alternative way to identify them.