### PR TITLE
DRAFT feat(vuetify2): set vuetify config from VAppLayout

### DIFF
--- a/trame_vuetify/module/vue2.py
+++ b/trame_vuetify/module/vue2.py
@@ -4,7 +4,7 @@ serve_path = str(Path(__file__).with_name("vue2-serve").resolve())
 serve = {"__trame_vuetify": serve_path}
 scripts = ["__trame_vuetify/trame-vuetify.umd.min.js"]
 styles = ["__trame_vuetify/trame-vuetify.css"]
-vue_use = ["trame_vuetify"]
+vue_use = [("trame_vuetify", "trame.state.get('trame__vuetify2_config')||{}")]
 
 
 def setup(server, **kargs):

--- a/trame_vuetify/ui/vuetify.py
+++ b/trame_vuetify/ui/vuetify.py
@@ -29,15 +29,18 @@ class VAppLayout(AbstractLayout):
 
     :param _server: Server to bound the layout to
     :param template_name: Name of the template (default: main)
+    :param vuetify_config: Dict structure to configure vuetify
     """
 
-    def __init__(self, _server, template_name="main", **kwargs):
+    def __init__(self, _server, template_name="main", vuetify_config=None, **kwargs):
         super().__init__(
             _server,
             vuetify.VApp(id="app", trame_server=_server),
             template_name=template_name,
             **kwargs,
         )
+        if vuetify_config:
+            self.server.state.trame__vuetify2_config = vuetify_config
 
 
 class SinglePageLayout(VAppLayout):

--- a/vue3/README.md
+++ b/vue3/README.md
@@ -1,6 +1,6 @@
 # trame-vuetify
 
-This directory capture the steps to enable Vuetify 3.x into trame-vuewtify.
+This directory capture the steps to enable Vuetify 3.x into trame-vuetify.
 
 ## Environment variables
 


### PR DESCRIPTION
This does not work yet:
 - trame expects the second element from the module to be a dict and not a string

This is not perfect:
 - how other modules (e.g. trame-gwc) are supposed to add their own config (e.g. icon aliases) without overwriting the one (e.g. themes) passed as parameter?