### PR TITLE
Fix: Replace applymap with map for dataframe serialization

### DIFF
--- a/trame_vuetify/widgets/vuetify.py
+++ b/trame_vuetify/widgets/vuetify.py
@@ -76,7 +76,7 @@ def dataframe_to_grid(dataframe, options={}):
         if options.get(col_name):
             headers[col_name].update(options.get(col_name))
 
-    return list(headers.values()), dataframe.applymap(cast_to_serializable).to_dict(
+    return list(headers.values()), dataframe.map(cast_to_serializable).to_dict(
         orient="records"
     )
 

--- a/trame_vuetify/widgets/vuetify3.py
+++ b/trame_vuetify/widgets/vuetify3.py
@@ -89,7 +89,7 @@ def dataframe_to_grid(dataframe, options={}):
         if options.get(col_name):
             headers[col_name].update(options.get(col_name))
 
-    return list(headers.values()), dataframe.applymap(cast_to_serializable).to_dict(
+    return list(headers.values()), dataframe.map(cast_to_serializable).to_dict(
         orient="records"
     )
 

--- a/vue2/.header.py
+++ b/vue2/.header.py
@@ -71,6 +71,6 @@ def dataframe_to_grid(dataframe, options={}):
         if options.get(col_name):
             headers[col_name].update(options.get(col_name))
 
-    return list(headers.values()), dataframe.applymap(cast_to_serializable).to_dict(
+    return list(headers.values()), dataframe.map(cast_to_serializable).to_dict(
         orient="records"
     )

--- a/vue3/.header.py
+++ b/vue3/.header.py
@@ -84,6 +84,6 @@ def dataframe_to_grid(dataframe, options={}):
         if options.get(col_name):
             headers[col_name].update(options.get(col_name))
 
-    return list(headers.values()), dataframe.applymap(cast_to_serializable).to_dict(
+    return list(headers.values()), dataframe.map(cast_to_serializable).to_dict(
         orient="records"
     )


### PR DESCRIPTION
This PR fixes a warning raised when using `dataframe_to_grid`:
```python
FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
  return list(headers.values()), dataframe.applymap(cast_to_serializable).to_dict(
```