### PR TITLE
fix(deps): bump minimal version of trame-client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Kitware Inc."},
 ]
 dependencies = [
-    "trame-client>=3.4,<4",
+    "trame-client>=3.7,<4",
 ]
 requires-python = ">=3.9"
 readme = "README.rst"


### PR DESCRIPTION
Bump minimal version of trame-client needed to expose latest Vue.js version (3.5.13)