### PR TITLE
Update pages job and README

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -48,7 +48,7 @@ jobs:
           cp -rf .vitepress/dist/logos .vitepress/dist/trame-vuetify/logos
           cp -rf .vitepress/dist/assets .vitepress/dist/trame-vuetify/assets
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ trame-vuetify can be installed with `pip <https://pypi.org/project/trame-vuetify
 Usage
 -----------------------------------------------------------
 
-The `Trame Tutorial <https://kitware.github.io/trame/docs/tutorial.html>`_ is the place to go to learn how to use the library and start building your own application.
+The `Trame Tutorial <https://kitware.github.io/trame/guide/tutorial>`_ is the place to go to learn how to use the library and start building your own application.
 
 The `API Reference <https://trame.readthedocs.io/en/latest/index.html>`_ documentation provides API-level documentation.
 
@@ -94,7 +94,7 @@ This license has been chosen to match the one use by `Vuetify <https://github.co
 Community
 -----------------------------------------------------------
 
-`Trame <https://kitware.github.io/trame/>`_ | `Discussions <https://github.com/Kitware/trame/discussions>`_ | `Issues <https://github.com/Kitware/trame/issues>`_ | `RoadMap <https://github.com/Kitware/trame/projects/1>`_ | `Contact Us <https://www.kitware.com/contact-us/>`_
+`Trame <https://kitware.github.io/trame/>`_ | `Discussions <https://github.com/Kitware/trame/discussions>`_ | `Issues <https://github.com/Kitware/trame/issues>`_ | `Contact Us <https://www.kitware.com/contact-us/>`_
 
 .. image:: https://zenodo.org/badge/410108340.svg
     :target: https://zenodo.org/badge/latestdoi/410108340


### PR DESCRIPTION
Looks like the job is failing due to deprecated `actions/upload-artifact@v3`: https://github.com/Kitware/trame-vuetify/actions/runs/14300847177/job/40074933451

Also, there were 2 broken links in the README.