### PR TITLE
style: update copyright date to 2026

### DIFF
--- a/trame_vuetify/ui/vuetify.py
+++ b/trame_vuetify/ui/vuetify.py
@@ -117,7 +117,7 @@ class SinglePageLayout(VAppLayout):
                 footer.add_child(
                     '<a href="https://www.kitware.com/" '
                     'class="grey--text lighten-1--text text-caption text-decoration-none" '
-                    'target="_blank">© 2025 Kitware Inc.</a>'
+                    'target="_blank">© 2022-2026 Kitware Inc.</a>'
                 )
 
     def on_server_reload(self):

--- a/trame_vuetify/ui/vuetify3.py
+++ b/trame_vuetify/ui/vuetify3.py
@@ -120,7 +120,7 @@ class SinglePageLayout(VAppLayout):
                 footer.add_child(
                     '<a href="https://www.kitware.com/" '
                     'class="text-grey-lighten-1 text-caption text-decoration-none" '
-                    'target="_blank">© 2025 Kitware Inc.</a>'
+                    'target="_blank">© 2022-2026 Kitware Inc.</a>'
                 )
 
     def on_server_reload(self):


### PR DESCRIPTION
@jourdain, @finetjul suggested using a "spanning" copyright like "2022-2026", should we ?

Also should we not fill VAppLayout's footer with the copyright by default ?